### PR TITLE
Sidebar Nav Arrow now points right when collapsed

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -146,6 +146,7 @@ const LinkList = styled(List)`
 
 const CollapseMenuItem = styled(MenuItemButton)`
   display: none;
+  transform: ${(props) => props.isCollapsed && "rotate(180deg)"};
 
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "prolog-app",
       "version": "14.5.1",
       "dependencies": {
         "@fontsource/inter": "^4.5.7",


### PR DESCRIPTION
The Arrow on the bottom of the sidebar now points the correct way when the sidebar is collapsed.